### PR TITLE
Remove hdfcbank.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,6 @@ Additionally, you can check out [#37](https://github.com/pirate/sites-using-clou
 - [hawamer.com](http://hawamer.com)
 - [hawkhost.com](http://hawkhost.com)
 - [hayah.cc](http://hayah.cc)
-- [hdfcbank.com](http://hdfcbank.com)
 - [healthkart.com](http://healthkart.com)
 - [heavy-r.com](http://heavy-r.com)
 - [hespress.com](http://hespress.com)


### PR DESCRIPTION
Removed hdfcbank.com as it is static site with publically available information.

Before submitting your pull-request:

 - name of the pull request should be "Add: domain, domain, domain (proxy + DNS)" or "Remove: domain (static), domain (DNS only), domain (static)"
 - do not ask for removal of actually affected websites (any websites using cloudflare reverse proxy)

### HOW TO REMOVE YOUR SITE
1. Verify the site is static and contains no user or sensitive data (I will remove it immediately once I confirm)  

OR  

1. Verify ownership, send me an email from @yourdomain.com, post a random nonce on the domain, or provide keybase proof
2. Verify you did not use the Cloudflare proxy service during the affected period 
